### PR TITLE
implement password reset related endpoints

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -43,3 +43,8 @@ class Profile(models.Model):
 
     def get_followers(self):
         return self.followers.all()
+
+class PasswordReset(models.Model):
+    email = models.EmailField()
+    token = models.CharField(max_length=100)
+    created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/music_app/urls.py
+++ b/backend/music_app/urls.py
@@ -22,6 +22,8 @@ from api import views
 urlpatterns = [
     path('api/login/', views.login, name='login'),
     path('api/register/', views.register, name='register'),
+    path('api/forget-password', views.forget_password, name='forget_password'),
+    path('api/reset-password', views.reset_password, name='reset_password'),
     path('api/get_user/', views.get_user, name='get_user'),
     path('api/logout/', views.logout, name='logout'),
     path('api/follow/<int:user_id>/', views.follow_user, name='follow_user'),

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      REACT_APP_BACKEND_URL: http://backend:8000/api/
+      REACT_APP_BACKEND_URL: http://0.0.0.0:8000/api/
       HOST: 0.0.0.0
     depends_on:
       - backend


### PR DESCRIPTION
closes #345 

Frontend should

```
POST /api/forget-password
{
  email: users email
}
```

have a page with url: `http://0.0.0.0:3000/reset/?token=`

token URL parameter will be filled with a token when user enters this page


on the page there should be two input boxes, new password and confirm password

then the frontend should

```
POST /api/reset-password
{
  token: token,
  new_password: new password,
  confirm_password: confirm password
}
```