### PR TITLE
Added profiles to the results of search

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -874,23 +874,36 @@ def search(request):
             # Q(ai_description__icontains=search_query)
 
         )
+
+        profiles = Profile.objects.filter(
+            Q(name__icontains=search_query) |
+            Q(surname__icontains=search_query) |
+            Q(user__username__icontains=search_query)  # Search by username
+        )
+
     else:
         contents = Content.objects.all()
+        profiles = Profile.objects.all()
 
-    total_results = contents.count()
+    content_results_count = contents.count()
+    profile_results_count = profiles.count()
 
     # Implement pagination
     start = (page - 1) * page_size
     end = start + page_size
     contents_paginated = contents[start:end]
+    profiles_paginated = profiles[start:end]
     
     content_list = list(contents_paginated.values())
+    profile_list = list(profiles_paginated.values())
 
     response = {
-        'total_results': total_results,
+        'content_results_count': content_results_count,
+        'profile_results_count': profile_results_count,
         'page': page,
         'page_size': page_size,
-        'contents': content_list
+        'contents': content_list,
+        'profiles': profile_list
     }
 
     return JsonResponse(response)


### PR DESCRIPTION
closes #552 


An example query and response is following:
`GET /search/?search=duman`
```json
{
    "content_results_count": 1,
    "profile_results_count": 1,
    "page": 1,
    "page_size": 10,
    "contents": [
        {
            "id": 2,
            "link": "https://open.spotify.com/track/5iHZGWJIDGPjnQEXpLnI3n",
            "content_type": "track",
            "artist_names": [
                "Duman"
            ],
            "playlist_name": "",
            "album_name": "Darmaduman",
            "song_name": "Sınana Sınana",
            "genres": [
                "Alternative Rock",
                "Indie Rock",
                "Grunge"
            ],
            "ai_description": "Sınana Sınana is a song by the Turkish rock band Duman from their album Darmaduman. Known for their alternative rock sound with poetic lyrics, Duman has been a prominent figure in the Turkish music scene since the early 2000s. Sınana Sınana showcases their signature blend of grunge and indie rock elements, with powerful vocals and raw instrumentation. The song's energetic and rebellious spirit resonated with a generation of Turkish youth, making it a standout track in Duman's discography.",
            "lyrics": null
        }
    ],
    "profiles": [
        {
            "id": 3,
            "user_id": 3,
            "name": "dumdum",
            "surname": "dumanf",
            "labels": "['Artist', 'Listener']"
        }
    ]
}
```
